### PR TITLE
don't execute useless System.get_env() calls. Set overseer autostart …

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,6 +40,9 @@ config :openaperture_manager_api,
   oauth_login_url: System.get_env("OAUTH_LOGIN_URL")         || "https://auth.host.co",
   oauth_client_id: System.get_env("OAUTH_CLIENT_ID")         || "id",
   oauth_client_secret: System.get_env("OAUTH_CLIENT_SECRET") || "secret"
+
+config :openaperture_manager_overseer_api,
+  autostart: false
   
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -44,3 +44,6 @@ config :openaperture_manager_api,
 	oauth_login_url: System.get_env("OAUTH_LOGIN_URL"),
 	oauth_client_id: System.get_env("OAUTH_CLIENT_ID"),
 	oauth_client_secret: System.get_env("OAUTH_CLIENT_SECRET")
+
+config :openaperture_manager_overseer_api,
+  autostart: true

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -41,3 +41,6 @@ config :openaperture_manager_api,
   oauth_login_url: System.get_env("OAUTH_LOGIN_URL"),
   oauth_client_id: System.get_env("OAUTH_CLIENT_ID"),
   oauth_client_secret: System.get_env("OAUTH_CLIENT_SECRET")
+
+config :openaperture_manager_overseer_api,
+  autostart: true

--- a/config/test.exs
+++ b/config/test.exs
@@ -20,6 +20,3 @@ config :openaperture_messaging,
 config OpenAperture.Manager, 
   exchange_id: "1",
   broker_id: "1"
-
-config :openaperture_manager_overseer_api,
-  autostart: false

--- a/lib/manager/configuration.ex
+++ b/lib/manager/configuration.ex
@@ -16,7 +16,6 @@ defmodule OpenAperture.Manager.Configuration do
   """ 
   @spec get_current_exchange_id() :: String.t()
   def get_current_exchange_id do
-    System.get_env()
     get_config("EXCHANGE_ID", OpenAperture.Manager, :exchange_id)
   end
 
@@ -31,7 +30,6 @@ defmodule OpenAperture.Manager.Configuration do
   """ 
   @spec get_current_broker_id() :: String.t()
   def get_current_broker_id do
-    System.get_env()
     get_config("BROKER_ID", OpenAperture.Manager, :broker_id)
   end
 


### PR DESCRIPTION
…to false by default